### PR TITLE
Blog app: add authorization rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'rubocop', '>= 1.0', '< 2.0'
 
 gem 'devise'
 
+gem 'cancancan'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     bootsnap (1.17.1)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -315,6 +316,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -145,3 +145,17 @@ textarea {
   height: 8vh;
   margin: 10px;
 }
+
+/* DELETE BUTTONS */
+.btn-delete {
+  background-color: #990525;
+  color: #fff;
+  border: none;
+  padding: 4px;
+}
+
+.comment_container {
+  display: flex;
+  justify-content: space-between;
+  width: 40vw;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
-# comments_controller.rb
 class CommentsController < ApplicationController
-  before_action :load_post, only: %i[new create]
+  before_action :load_post, only: %i[new create destroy]
+  before_action :load_comment, only: [:destroy]
 
   def new
     @comment = @post.comments.new
@@ -18,6 +18,11 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment.destroy
+    redirect_to post_path(@post), notice: 'Comment was successfully deleted.'
+  end
+
   private
 
   def load_post
@@ -26,5 +31,9 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(:text)
+  end
+
+  def load_comment
+    @comment = @post.comments.find(params[:id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  load_and_authorize_resource
+
   def index
     @user = User.includes(posts: :comments).find(params[:user_id])
     @posts = @user.posts
@@ -10,6 +12,7 @@ class PostsController < ApplicationController
   end
 
   def show
+    @user = current_user
     @post = Post.find(params[:id])
     @comments = @post.comments
     @author_name = @post.author.name
@@ -26,6 +29,13 @@ class PostsController < ApplicationController
     else
       render 'users/show'
     end
+  end
+
+  def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+
+    redirect_to user_posts_path(current_user), notice: 'Post was deleted succesfully'
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,15 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :read, :all
+
+    if user.admin?
+      can :manage, :all
+    else
+      can :create, [Post, Comment]
+      can :manage, Post, author_id: user.id
+      can :manage, Comment, user_id: user.id
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,6 +4,7 @@ class Comment < ApplicationRecord
   belongs_to :post
 
   after_create :update_post_comments_counter
+  after_destroy :update_post_comments_counter
 
   private
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,7 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
 
   after_create :update_author_posts_counter
+  after_destroy :update_author_posts_counter
 
   def update_author_posts_counter
     author.update(posts_counter: author.posts.count)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
+  def admin?
+    role == 'admin'
+  end
+
   def recent_posts(limit = 3)
     posts.order(created_at: :desc).limit(limit)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= turbo_frame_tag 'reload' %>
   </head>
 
   <body>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,7 +19,7 @@
 
     <% if can? :destroy, @post %>
         <%= form_with(model: [@user, @post], method: :delete, data: { turbo_frame: 'reload' }) do |form| %>
-            <%= form.submit 'Delete Post', class: 'btn', data: { confirm: 'Are you sure?' } %>
+            <%= form.submit 'Delete Post', class: 'btn-delete', data: { confirm: 'Are you sure?' } %>
         <% end %>
     <% end %>
 </div>
@@ -32,7 +32,7 @@
                 "<%= comment.text %>"
                 <% if can? :destroy, comment %>
                     <%= form_with(model: [@post, comment], method: :delete, url: user_post_comment_path(@user, @post, comment), data: { turbo_frame: 'reload' }) do |form| %>
-                    <%= form.submit 'Delete Comment', class: 'btn', data: { confirm: 'Are you sure?' } %>
+                    <%= form.submit 'Delete Comment', class: 'btn-delete', data: { confirm: 'Are you sure?' } %>
                     <% end %>
                 <% end %>
             </li>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,6 +8,7 @@
         </div>
     </div>
     <p class="post-details-text"><%= @post.text %></p>
+    <p class="post-details-text"><%= @user.role %></p>
 
 
     <!-- Comments Form -->
@@ -15,6 +16,12 @@
 
     <!-- Likes Form -->
     <%= render 'likes/form' %>
+
+    <% if can? :destroy, @post %>
+        <%= form_with(model: [@user, @post], method: :delete, data: { turbo_frame: 'reload' }) do |form| %>
+            <%= form.submit 'Delete Post', class: 'btn', data: { confirm: 'Are you sure?' } %>
+        <% end %>
+    <% end %>
 </div>
 
 <div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,6 @@
         </div>
     </div>
     <p class="post-details-text"><%= @post.text %></p>
-    <p class="post-details-text"><%= @user.role %></p>
 
 
     <!-- Comments Form -->
@@ -28,7 +27,7 @@
     <h2>Comments:</h2>
     <ul>
         <% @comments.each do |comment| %>
-            <li>
+            <li class="comment_container">
                 "<%= comment.text %>"
                 <% if can? :destroy, comment %>
                     <%= form_with(model: [@post, comment], method: :delete, url: user_post_comment_path(@user, @post, comment), data: { turbo_frame: 'reload' }) do |form| %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,7 +28,14 @@
     <h2>Comments:</h2>
     <ul>
         <% @comments.each do |comment| %>
-            <li>"<%= comment.text %>"</li>
-        <% end %>
+            <li>
+                "<%= comment.text %>"
+                <% if can? :destroy, comment %>
+                    <%= form_with(model: [@post, comment], method: :delete, url: user_post_comment_path(@user, @post, comment), data: { turbo_frame: 'reload' }) do |form| %>
+                    <%= form.submit 'Delete Comment', class: 'btn', data: { confirm: 'Are you sure?' } %>
+                    <% end %>
+                <% end %>
+            </li>
+        <% end %>      
     </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :show] do
     resources :posts, only: [:index, :show, :new, :create, :destroy] do
-      resources :comments, only: [:new, :create]
+      resources :comments, only: [:new, :create, :destroy]
       resources :likes, only: [:create]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,13 +5,13 @@ Rails.application.routes.draw do
   root "users#index"
 
   resources :users, only: [:index, :show] do
-    resources :posts, only: [:index, :show, :new, :create] do
+    resources :posts, only: [:index, :show, :new, :create, :destroy] do
       resources :comments, only: [:new, :create]
       resources :likes, only: [:create]
     end
   end
 
-  resources :posts, only: [:index, :show]
+  resources :posts, only: [:index, :show, :destroy]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/db/migrate/20240126140053_add_role_to_users.rb
+++ b/db/migrate/20240126140053_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :role, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_24_191519) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_140053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_191519) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role", default: ""
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# CanCanCan Integration and Authorization

### Install CanCanCan

- Integrated CanCanCan into the project for managing authorization.

### Add Role Column

- Added a `role` column to the `users` table using a migration.

### Post Deletion Authorization

- Implemented authorization for post deletion using CanCanCan.
- Users can delete a post if it belongs to them or if they have an admin role ("admin").
- Added the "Delete" button to the post view, ensuring only authorized users can see it.

### Comment Deletion Authorization

- Implemented authorization for comment deletion using CanCanCan.
- Users can delete a comment if it belongs to them or if they have an admin role ("admin").
- Added the "Delete" button to the comment view, ensuring only authorized users can see it.

